### PR TITLE
Refactor: Updating to Dart 2.18

### DIFF
--- a/lib/backendless_sdk.dart
+++ b/lib/backendless_sdk.dart
@@ -2,8 +2,6 @@ library backendless_sdk;
 
 import 'dart:collection';
 import 'dart:io';
-import 'dart:typed_data';
-import 'dart:ui' show hashValues;
 import 'dart:convert';
 
 import 'package:collection/collection.dart';

--- a/lib/src/modules/data/geo/line_string.dart
+++ b/lib/src/modules/data/geo/line_string.dart
@@ -11,7 +11,7 @@ class LineString extends Geometry {
       other is LineString && listEquals(points, other.points);
 
   @override
-  int get hashCode => hashValues(points, srs);
+  int get hashCode => Object.hash(points, srs);
 
   LineString({List<Point>? points, SpatialReferenceSystem? srs})
       : super(srs: srs) {

--- a/lib/src/modules/data/geo/point.dart
+++ b/lib/src/modules/data/geo/point.dart
@@ -20,7 +20,7 @@ class Point extends Geometry {
       (other.y - y).abs() < Point.precision;
 
   @override
-  int get hashCode => hashValues(x, y, srs);
+  int get hashCode => Object.hash(x, y, srs);
 
   Point({this.x = 0.0, this.y = 0.0, SpatialReferenceSystem? srs})
       : super(srs: srs);

--- a/lib/src/modules/messaging/status.dart
+++ b/lib/src/modules/messaging/status.dart
@@ -33,7 +33,7 @@ class MessageStatus implements Comparable<MessageStatus> {
           this.status == other.status;
 
   @override
-  int get hashCode => hashValues(messageId, status);
+  int get hashCode => Object.hash(messageId, status);
 
   @override
   String toString() =>

--- a/lib/src/web/call_handlers/files.dart
+++ b/lib/src/web/call_handlers/files.dart
@@ -3,7 +3,6 @@
 library backendless_files_web;
 
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:js/js.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 7.2.5
 homepage: https://backendless.com
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
   flutter: ">=1.10.0"
 
 dependencies:


### PR DESCRIPTION
A small refactor to upgrade to Dart 2.18
- Removed unnecessary import `dart:typed_data`  is  already provided by the import `flutter/foundation.dart`
- `hasValues` is deprecated, now using `Object.hash` instead.

Thanks for this SDK
All-Win Software Team